### PR TITLE
Add support for modifying routines

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+fivethreeone.db
+fivethreeone.db.*
+stronk.db
+stronk.db.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 routine.json
+routine.json.bak
 hashkey.dat
 blockkey.dat
 fivethreeone.db
 fivethreeone.db.*
-stronk.db
-stronk.db.*
+stronk.db*

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ COPY testing/ /project/testing
 # Needed for testing
 COPY routine.example.json /project
 
-# RUN go test ./... && GOOS=linux go build -ldflags "-linkmode external -extldflags -static" -o stronk github.com/bcspragu/stronk/cmd/server
-RUN GOOS=linux go build -ldflags "-linkmode external -extldflags -static" -o stronk github.com/bcspragu/stronk/cmd/server
+RUN go test ./... && GOOS=linux go build -ldflags "-linkmode external -extldflags -static" -o stronk github.com/bcspragu/stronk/cmd/server
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /project/stronk /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t 192.168.5.3:5000/stronk .
-FROM golang:1.24 as build
+FROM golang:1.24 AS build
 
 WORKDIR /project
 
@@ -14,7 +14,8 @@ COPY testing/ /project/testing
 # Needed for testing
 COPY routine.example.json /project
 
-RUN go test ./... && GOOS=linux go build -ldflags "-linkmode external -extldflags -static" -o stronk github.com/bcspragu/stronk/cmd/server
+# RUN go test ./... && GOOS=linux go build -ldflags "-linkmode external -extldflags -static" -o stronk github.com/bcspragu/stronk/cmd/server
+RUN GOOS=linux go build -ldflags "-linkmode external -extldflags -static" -o stronk github.com/bcspragu/stronk/cmd/server
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /project/stronk /

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,7 +37,7 @@ func run() error {
 		return fmt.Errorf("failed to load users file: %v", err)
 	}
 
-	db, err := sqldb.New(*dbFile, *migrationDir)
+	db, err := sqldb.New(*dbFile, *migrationDir, routine)
 	if err != nil {
 		return fmt.Errorf("failed to load SQLite db: %v", err)
 	}

--- a/db/sqldb/migrations/20250824124147_routine_system.down.sql
+++ b/db/sqldb/migrations/20250824124147_routine_system.down.sql
@@ -1,0 +1,7 @@
+-- Drop the new routine system tables in reverse order (respecting foreign keys)
+DROP TABLE IF EXISTS lifts_new;
+DROP TABLE IF EXISTS routine_sets;
+DROP TABLE IF EXISTS routine_movements;
+DROP TABLE IF EXISTS routine_days;
+DROP TABLE IF EXISTS routine_weeks;
+DROP TABLE IF EXISTS routines;

--- a/db/sqldb/migrations/20250824124147_routine_system.down.sql
+++ b/db/sqldb/migrations/20250824124147_routine_system.down.sql
@@ -1,7 +1,7 @@
 -- Drop the new routine system tables in reverse order (respecting foreign keys)
-DROP TABLE IF EXISTS lifts_new;
-DROP TABLE IF EXISTS routine_sets;
-DROP TABLE IF EXISTS routine_movements;
-DROP TABLE IF EXISTS routine_days;
-DROP TABLE IF EXISTS routine_weeks;
-DROP TABLE IF EXISTS routines;
+DROP TABLE lifts_new;
+DROP TABLE routine_sets;
+DROP TABLE routine_movements;
+DROP TABLE routine_days;
+DROP TABLE routine_weeks;
+DROP TABLE routines;

--- a/db/sqldb/migrations/20250824124147_routine_system.up.sql
+++ b/db/sqldb/migrations/20250824124147_routine_system.up.sql
@@ -1,0 +1,63 @@
+-- Create the new routine system tables
+
+-- Routines table - represents a routine loaded into the system
+CREATE TABLE routines (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  name TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now'))
+);
+
+-- Routine weeks table - represents a week within a routine
+CREATE TABLE routine_weeks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  routine_id INTEGER NOT NULL,
+  week_name TEXT NOT NULL,
+  optional INTEGER NOT NULL DEFAULT FALSE,
+  week_order INTEGER NOT NULL, -- 0-based ordering within the routine
+  FOREIGN KEY (routine_id) REFERENCES routines (id)
+);
+
+-- Routine days table - represents a day within a routine week
+CREATE TABLE routine_days (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  routine_week_id INTEGER NOT NULL,
+  day_name TEXT NOT NULL,
+  day_order INTEGER NOT NULL, -- 0-based ordering within the week
+  FOREIGN KEY (routine_week_id) REFERENCES routine_weeks (id)
+);
+
+-- Routine movements table - represents a group of sets (warmup, main, assistance)
+CREATE TABLE routine_movements (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  routine_day_id INTEGER NOT NULL,
+  exercise_id INTEGER NOT NULL,
+  set_type TEXT CHECK( set_type IN ('WARMUP', 'MAIN', 'ASSISTANCE') ) NOT NULL,
+  movement_order INTEGER NOT NULL, -- 0-based ordering within the day
+  FOREIGN KEY (routine_day_id) REFERENCES routine_days (id),
+  FOREIGN KEY (exercise_id) REFERENCES exercises (id)
+);
+
+-- Routine sets table - represents individual sets within a movement
+CREATE TABLE routine_sets (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  routine_movement_id INTEGER NOT NULL,
+  rep_target INTEGER NOT NULL,
+  to_failure INTEGER NOT NULL DEFAULT FALSE,
+  training_max_percentage INTEGER NOT NULL,
+  set_order INTEGER NOT NULL, -- 0-based ordering within the movement
+  FOREIGN KEY (routine_movement_id) REFERENCES routine_movements (id)
+);
+
+-- New lifts table structure - references routine sets instead of storing all the metadata
+CREATE TABLE lifts_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  routine_set_id INTEGER NOT NULL,
+  weight TEXT NOT NULL,
+  reps INTEGER, -- NULL if same as routine, or for non-failure sets
+  lift_note TEXT,
+  day_number INTEGER NOT NULL,
+  week_number INTEGER NOT NULL,
+  iteration_number INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
+  FOREIGN KEY (routine_set_id) REFERENCES routine_sets (id)
+);

--- a/db/sqldb/migrations/20250824124147_routine_system.up.sql
+++ b/db/sqldb/migrations/20250824124147_routine_system.up.sql
@@ -4,7 +4,7 @@
 CREATE TABLE routines (
   id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   name TEXT NOT NULL,
-  created_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now'))
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Routine weeks table - represents a week within a routine
@@ -53,11 +53,12 @@ CREATE TABLE lifts_new (
   id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   routine_set_id INTEGER NOT NULL,
   weight TEXT NOT NULL,
-  reps INTEGER, -- NULL if same as routine, or for non-failure sets
+  reps INTEGER NOT NULL,
   lift_note TEXT,
-  day_number INTEGER NOT NULL,
-  week_number INTEGER NOT NULL,
-  iteration_number INTEGER NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
   FOREIGN KEY (routine_set_id) REFERENCES routine_sets (id)
 );
+
+-- This is important! Basic queries will be quite slow otherwise.
+-- I measured this at 370ms vs 7ms (a 50x reduction) on my personal instance.
+CREATE INDEX idx_lifts_created_at ON lifts_new (created_at);

--- a/db/sqldb/migrations/20250824125512_finalize_routine_migration.down.sql
+++ b/db/sqldb/migrations/20250824125512_finalize_routine_migration.down.sql
@@ -1,0 +1,22 @@
+-- Reverse the finalization - restore the old lifts table structure
+-- Note: This will lose data in the new format
+
+-- Rename current lifts table back to lifts_new
+ALTER TABLE lifts RENAME TO lifts_new;
+
+-- Recreate the old lifts table structure
+CREATE TABLE lifts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  exercise_id NOT NULL,
+  set_type TEXT CHECK( set_type IN ('WARMUP', 'MAIN', 'ASSISTANCE') ) NOT NULL,
+  set_number INTEGER NOT NULL,
+  reps INTEGER NOT NULL,
+  weight TEXT NOT NULL,
+  day_number INTEGER NOT NULL,
+  week_number INTEGER NOT NULL,
+  iteration_number INTEGER NOT NULL,
+  lift_note TEXT,
+  to_failure INTEGER NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
+  FOREIGN KEY (exercise_id) REFERENCES exercises (id)
+);

--- a/db/sqldb/migrations/20250824125512_finalize_routine_migration.up.sql
+++ b/db/sqldb/migrations/20250824125512_finalize_routine_migration.up.sql
@@ -1,0 +1,8 @@
+-- This migration should be run AFTER the data migration is complete
+-- It replaces the old lifts table with the new one
+
+-- Drop the old lifts table
+DROP TABLE lifts;
+
+-- Rename the new lifts table to replace the old one
+ALTER TABLE lifts_new RENAME TO lifts;

--- a/db/sqldb/sqldb.go
+++ b/db/sqldb/sqldb.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -18,6 +19,33 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
+const baseLiftQuery = `
+SELECT
+	lifts.id,
+	routine_sets.id,
+	exercises.name,
+	routine_movements.set_type,
+	lifts.weight,
+	routine_sets.set_order,
+	lifts.reps,
+	lifts.lift_note,
+	routine_days.day_order,
+	routine_weeks.week_order,
+	(SELECT COUNT(routine_set_id)-1 FROM lifts lifts2 WHERE lifts2.created_at <= lifts.created_at GROUP BY routine_set_id),
+	routine_sets.to_failure
+FROM lifts
+JOIN routine_sets
+	ON lifts.routine_set_id = routine_sets.id
+JOIN routine_movements
+	ON routine_sets.routine_movement_id = routine_movements.id
+JOIN routine_days
+	ON routine_movements.routine_day_id = routine_days.id
+JOIN routine_weeks
+	ON routine_days.routine_week_id = routine_weeks.id
+JOIN exercises
+	ON routine_movements.exercise_id = exercises.id
+`
+
 type DB struct {
 	mu          sync.Mutex
 	sql         *sql.DB
@@ -28,31 +56,10 @@ func (db *DB) Close() error {
 	return db.sql.Close()
 }
 
-type scanner interface {
-	Scan(dest ...interface{}) error
-}
-
-func (db *DB) EditLift(id stronk.LiftID, note string, reps int) error {
-	return db.transact(func(tx *sql.Tx) error {
-		q := `
-UPDATE lifts
-	SET reps = ?, lift_note = ?
-WHERE id = ?
-`
-		_, err := tx.Exec(q, reps, note, id)
-		return err
-	})
-}
-
 func (db *DB) Lift(id stronk.LiftID) (*stronk.Lift, error) {
 	var lift *stronk.Lift
 	err := db.transact(func(tx *sql.Tx) error {
-		q := `
-SELECT lifts.id, exercises.name, lifts.set_type, lifts.weight, lifts.set_number, lifts.reps, lifts.lift_note, lifts.day_number, lifts.week_number, lifts.iteration_number, lifts.to_failure
-FROM lifts
-JOIN exercises
-	ON lifts.exercise_id = exercises.id
-WHERE lifts.id = ?`
+		q := baseLiftQuery + `WHERE lifts.id = ?`
 
 		rows, err := tx.Query(q, id)
 		if err != nil {
@@ -72,24 +79,6 @@ WHERE lifts.id = ?`
 		return nil, fmt.Errorf("failed to set lifts: %w", err)
 	}
 	return lift, nil
-}
-
-func (db *DB) RecordLift(ex stronk.Exercise, st stronk.SetType, weight stronk.Weight, set int, reps int, note string, day, week, iter int, toFailure bool) (stronk.LiftID, error) {
-	var id stronk.LiftID
-	err := db.transact(func(tx *sql.Tx) error {
-		q := `INSERT INTO lifts
-(exercise_id, set_type, set_number, reps, weight, day_number, week_number, iteration_number, lift_note, to_failure)
-VALUES ((SELECT id FROM exercises WHERE name = ?), ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING lifts.id`
-		if err := tx.QueryRow(q, ex, st, set, reps, &sqlWeight{&weight}, day, week, iter, nullString(note), toFailure).Scan(&id); err != nil {
-			return fmt.Errorf("failed to insert lift: %w", err)
-		}
-		return nil
-	})
-	if err != nil {
-		return 0, err
-	}
-	return id, nil
 }
 
 func (db *DB) SkippedWeeks() ([]stronk.SkippedWeek, error) {
@@ -134,22 +123,18 @@ func (db *DB) ComparableLifts(ex stronk.Exercise, weight stronk.Weight) (*stronk
 	//  2. The highest ORM equivalent reps, period. ("PR")
 	var lfs []*stronk.Lift
 	err := db.transact(func(tx *sql.Tx) error {
-		q := `
-SELECT lifts.id, exercises.name, lifts.set_type, lifts.weight, lifts.set_number, lifts.reps, lifts.lift_note, lifts.day_number, lifts.week_number, lifts.iteration_number, lifts.to_failure
-FROM lifts
-JOIN exercises
-	ON lifts.exercise_id = exercises.id
+		q := baseLiftQuery + `
 WHERE exercises.name = ?
-	AND to_failure = TRUE
-ORDER BY iteration_number DESC, week_number DESC, day_number DESC, lifts.created_at DESC
+	AND routine_sets.to_failure = TRUE
+ORDER BY lifts.created_at DESC
 LIMIT 250`
 
 		rows, err := tx.Query(q, ex)
 		if err != nil {
-			return fmt.Errorf("failed to query lifts: %w", err)
+			return fmt.Errorf("failed to query comparable lifts: %w", err)
 		}
 		if lfs, err = lifts(rows); err != nil {
-			return fmt.Errorf("failed to scan lifts: %w", err)
+			return fmt.Errorf("failed to scan comparable lifts: %w", err)
 		}
 		return nil
 	})
@@ -163,14 +148,10 @@ LIMIT 250`
 func (db *DB) RecentFailureSets() ([]*stronk.Lift, error) {
 	var lfs []*stronk.Lift
 	err := db.transact(func(tx *sql.Tx) error {
-		q := `
-SELECT lifts.id, exercises.name, lifts.set_type, lifts.weight, lifts.set_number, lifts.reps, lifts.lift_note, lifts.day_number, lifts.week_number, lifts.iteration_number, lifts.to_failure
-FROM lifts
-JOIN exercises
-	ON lifts.exercise_id = exercises.id
-WHERE set_type = 'MAIN'
-	AND to_failure = TRUE
-ORDER BY iteration_number DESC, week_number DESC, day_number DESC, lifts.created_at DESC
+		q := baseLiftQuery + `
+WHERE routine_movements.set_type = 'MAIN'
+	AND routine_sets.to_failure = TRUE
+ORDER BY created_at DESC
 LIMIT 250`
 
 		rows, err := tx.Query(q)
@@ -188,16 +169,34 @@ LIMIT 250`
 	return lfs, nil
 }
 
+func (db *DB) LatestLift() (*stronk.Lift, error) {
+	var lf *stronk.Lift
+	err := db.transact(func(tx *sql.Tx) error {
+		q := baseLiftQuery + `
+ORDER BY lifts.created_at DESC
+LIMIT 1
+`
+
+		theLift, err := lift(tx.QueryRow(q))
+		if err != nil {
+			return fmt.Errorf("failed to load latest lift: %w", err)
+		}
+		lf = theLift
+		return nil
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to set lifts: %w", err)
+	}
+	return lf, nil
+}
+
 func (db *DB) RecentLifts() ([]*stronk.Lift, error) {
 	var lfs []*stronk.Lift
 	err := db.transact(func(tx *sql.Tx) error {
-		q := `
-SELECT lifts.id, exercises.name, lifts.set_type, lifts.weight, lifts.set_number, lifts.reps, lifts.lift_note, lifts.day_number, lifts.week_number, lifts.iteration_number, lifts.to_failure
-FROM lifts
-JOIN exercises
-	ON lifts.exercise_id = exercises.id
-ORDER BY iteration_number DESC, week_number DESC, day_number DESC, lifts.created_at DESC
-LIMIT 100`
+		q := baseLiftQuery + `LIMIT 100`
 
 		rows, err := tx.Query(q)
 		if err != nil {
@@ -212,6 +211,46 @@ LIMIT 100`
 		return nil, fmt.Errorf("failed to set lifts: %w", err)
 	}
 	return lfs, nil
+}
+
+func (db *DB) LatestLiftPerSetID(setIDs []stronk.RoutineSetID) (map[stronk.RoutineSetID]*stronk.Lift, error) {
+	var lfs []*stronk.Lift
+	err := db.transact(func(tx *sql.Tx) error {
+		q := baseLiftQuery + fmt.Sprintf(`
+WHERE routine_sets.id IN %s
+LIMIT 100`, repeatedArgs(len(setIDs)))
+
+		args := make([]any, 0, len(setIDs))
+		for _, id := range setIDs {
+			args = append(args, id)
+		}
+
+		rows, err := tx.Query(q, args...)
+		if err != nil {
+			return fmt.Errorf("failed to query lifts: %w", err)
+		}
+		if lfs, err = lifts(rows); err != nil {
+			return fmt.Errorf("failed to scan lifts: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get lifts: %w", err)
+	}
+	m := make(map[stronk.RoutineSetID][]*stronk.Lift)
+	for _, lf := range lfs {
+		m[lf.RoutineSetID] = append(m[lf.RoutineSetID], lf)
+	}
+	for _, lfs := range m {
+		slices.SortFunc(lfs, func(a, b *stronk.Lift) int {
+			return b.IterationNumber - a.IterationNumber
+		})
+	}
+	out := make(map[stronk.RoutineSetID]*stronk.Lift)
+	for id, lfs := range m {
+		out[id] = lfs[0]
+	}
+	return out, nil
 }
 
 func (db *DB) transact(dbFn func(tx *sql.Tx) error) error {
@@ -240,7 +279,7 @@ func (db *DB) SetTrainingMaxes(press, squat, bench, deadlift stronk.Weight) erro
 		q := `INSERT INTO training_maxes
 (exercise_id, training_max_weight) VALUES
 (?, ?), (?, ?), (?, ?), (?, ?)`
-		args := []interface{}{
+		args := []any{
 			db.mainLiftIDs[stronk.OverheadPress], &sqlWeight{&press},
 			db.mainLiftIDs[stronk.Squat], &sqlWeight{&squat},
 			db.mainLiftIDs[stronk.BenchPress], &sqlWeight{&bench},
@@ -344,27 +383,39 @@ LIMIT 1`
 	return small, nil
 }
 
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func lift(sc scanner) (*stronk.Lift, error) {
+	var (
+		lf   stronk.Lift
+		note sql.NullString
+	)
+	if err := sc.Scan(
+		&lf.ID, &lf.RoutineSetID,
+		&lf.Exercise, &lf.SetType, &sqlWeight{&lf.Weight},
+		&lf.SetNumber, &lf.Reps, &note,
+		&lf.DayNumber, &lf.WeekNumber, &lf.IterationNumber,
+		&lf.ToFailure); err != nil {
+		return nil, fmt.Errorf("failed to scan lift: %w", err)
+	}
+	if note.Valid {
+		lf.Note = note.String
+	}
+	return &lf, nil
+}
+
 func lifts(rows *sql.Rows) ([]*stronk.Lift, error) {
 	defer rows.Close()
 
 	var lfs []*stronk.Lift
 	for rows.Next() {
-		var (
-			lf   stronk.Lift
-			note sql.NullString
-		)
-		if err := rows.Scan(
-			&lf.ID,
-			&lf.Exercise, &lf.SetType, &sqlWeight{&lf.Weight},
-			&lf.SetNumber, &lf.Reps, &note,
-			&lf.DayNumber, &lf.WeekNumber, &lf.IterationNumber,
-			&lf.ToFailure); err != nil {
-			return nil, fmt.Errorf("failed to scan lift: %w", err)
+		lf, err := lift(rows)
+		if err != nil {
+			return nil, err
 		}
-		if note.Valid {
-			lf.Note = note.String
-		}
-		lfs = append(lfs, &lf)
+		lfs = append(lfs, lf)
 	}
 
 	if err := rows.Err(); err != nil {
@@ -391,7 +442,7 @@ func skippedWeeks(rows *sql.Rows) ([]stronk.SkippedWeek, error) {
 	return wks, nil
 }
 
-func New(dbPath, migrationsPath string) (*DB, error) {
+func New(dbPath, migrationsPath string, routine *stronk.Routine) (*DB, error) {
 	db, err := sql.Open("sqlite3", dbPath+"?_loc=UTC")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open SQLite DB: %w", err)
@@ -455,6 +506,36 @@ func New(dbPath, migrationsPath string) (*DB, error) {
 		return nil, cleanupOnError(errors.New("database was marked dirty"))
 	}
 
+	sdb := &DB{sql: db}
+
+	// 20250820053857 is millisecond_precision_on_lifts, the last migration before
+	// our manual backfill with the new routine system.
+	if prevV <= 20250820053857 {
+		// Upgrade to where we introduce the new table in 20250824124147_routine_system
+		log.Println("Migrating DB to 20250824124147 to prepare for routine/lift migration")
+		if err := m.Migrate(20250824124147); err != nil {
+			return nil, cleanupOnError(fmt.Errorf("failed to migrate to new routine version: %w", err))
+		}
+
+		// Required if this is a fresh DB
+		if err := sdb.initMainLifts(); err != nil {
+			return nil, fmt.Errorf("failed to init main lifts: %w", err)
+		}
+
+		// Since we just did the migration, we know that we have no routines in our
+		// `routines` table, so store the first one.
+		storedRoutine, err := sdb.StoreRoutine(routine)
+		if err != nil {
+			return nil, cleanupOnError(fmt.Errorf("failed to store initial routine in DB: %w", err))
+		}
+
+		// Now do the manual migration
+		log.Println("Copying lifts to the new table")
+		if err := sdb.MigrateLiftsToNewFormat(storedRoutine); err != nil {
+			return nil, cleanupOnError(fmt.Errorf("failed to migrate lifts to new DB table: %w", err))
+		}
+	}
+
 	switch err := m.Up(); {
 	case err == nil:
 		// Fine, good.
@@ -475,8 +556,6 @@ func New(dbPath, migrationsPath string) (*DB, error) {
 	if prevV != curV {
 		log.Printf("Migrated from version %d to version %d", prevV, curV)
 	}
-
-	sdb := &DB{sql: db}
 
 	if err := sdb.initMainLifts(); err != nil {
 		return nil, fmt.Errorf("failed to init main lifts: %w", err)
@@ -515,7 +594,7 @@ SELECT id, name
 FROM exercises
 WHERE name IN %s`, repeatedArgs(len(exs)))
 
-		var args []interface{}
+		var args []any
 		for _, ex := range exs {
 			args = append(args, ex)
 		}
@@ -569,15 +648,15 @@ func (db *DB) initMainLifts() error {
 	return nil
 }
 
-// GetCurrentRoutine returns the most recently stored routine
+// GetCurrentRoutine returns the most recently stored routine.
 func (db *DB) GetCurrentRoutine() (*stronk.StoredRoutine, error) {
 	var routine *stronk.StoredRoutine
 	err := db.transact(func(tx *sql.Tx) error {
 		// Get the most recent routine
 		routineQuery := `
-		SELECT id, name, created_at 
-		FROM routines 
-		ORDER BY created_at DESC 
+		SELECT id, name, created_at
+		FROM routines
+		ORDER BY created_at DESC
 		LIMIT 1`
 
 		var r stronk.StoredRoutine
@@ -614,7 +693,7 @@ func (db *DB) GetCurrentRoutine() (*stronk.StoredRoutine, error) {
 
 		// Load days
 		if len(r.Weeks) > 0 {
-			var weekIDs []interface{}
+			var weekIDs []any
 			for _, week := range r.Weeks {
 				weekIDs = append(weekIDs, week.ID)
 			}
@@ -643,7 +722,7 @@ func (db *DB) GetCurrentRoutine() (*stronk.StoredRoutine, error) {
 
 			// Load movements if we have days
 			if len(dayMap) > 0 {
-				var dayIDs []interface{}
+				var dayIDs []any
 				for dayID := range dayMap {
 					dayIDs = append(dayIDs, dayID)
 				}
@@ -673,7 +752,7 @@ func (db *DB) GetCurrentRoutine() (*stronk.StoredRoutine, error) {
 
 				// Load sets if we have movements
 				if len(movementMap) > 0 {
-					var movementIDs []interface{}
+					var movementIDs []any
 					for movementID := range movementMap {
 						movementIDs = append(movementIDs, movementID)
 					}
@@ -812,16 +891,16 @@ func (db *DB) GetRoutineSet(id stronk.RoutineSetID) (*stronk.StoredRoutineSet, e
 	return set, nil
 }
 
-// RecordLiftNew records a lift using the new routine system
-func (db *DB) RecordLiftNew(routineSetID stronk.RoutineSetID, weight stronk.Weight, reps *int, note string, day, week, iter int) (stronk.LiftID, error) {
+// RecordLift records a lift using the new routine system
+func (db *DB) RecordLift(routineSetID stronk.RoutineSetID, reps int, note string, weight stronk.Weight) (stronk.LiftID, error) {
 	var id stronk.LiftID
 	err := db.transact(func(tx *sql.Tx) error {
 		query := `
-		INSERT INTO lifts_new (routine_set_id, weight, reps, lift_note, day_number, week_number, iteration_number)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO lifts (routine_set_id, reps, lift_note, weight)
+		VALUES (?, ?, ?, ?)
 		RETURNING id`
 
-		if err := tx.QueryRow(query, routineSetID, &sqlWeight{&weight}, reps, nullString(note), day, week, iter).Scan(&id); err != nil {
+		if err := tx.QueryRow(query, routineSetID, reps, nullString(note), &sqlWeight{&weight}).Scan(&id); err != nil {
 			return fmt.Errorf("failed to insert lift: %w", err)
 		}
 		return nil
@@ -832,11 +911,11 @@ func (db *DB) RecordLiftNew(routineSetID stronk.RoutineSetID, weight stronk.Weig
 	return id, nil
 }
 
-// EditLiftNew edits a lift using the new system
-func (db *DB) EditLiftNew(id stronk.LiftID, note string, reps *int) error {
+// EditLift edits a lift using the new system
+func (db *DB) EditLift(id stronk.LiftID, note string, reps int) error {
 	return db.transact(func(tx *sql.Tx) error {
 		query := `
-		UPDATE lifts_new
+		UPDATE lifts
 		SET reps = ?, lift_note = ?
 		WHERE id = ?`
 		_, err := tx.Exec(query, reps, nullString(note), id)
@@ -850,8 +929,7 @@ func (db *DB) MigrateLiftsToNewFormat(storedRoutine *stronk.StoredRoutine) error
 	return db.transact(func(tx *sql.Tx) error {
 		// Get all existing lifts
 		liftsQuery := `
-		SELECT l.id, e.name, l.set_type, l.weight, l.set_number, l.reps, l.lift_note,
-		       l.day_number, l.week_number, l.iteration_number, l.to_failure
+		SELECT l.id, e.name, l.set_type, l.weight, l.set_number, l.reps, l.lift_note, l.day_number, l.week_number, l.iteration_number, l.to_failure, l.created_at
 		FROM lifts l
 		JOIN exercises e ON l.exercise_id = e.id
 		ORDER BY l.iteration_number, l.week_number, l.day_number, l.created_at`
@@ -876,15 +954,18 @@ func (db *DB) MigrateLiftsToNewFormat(storedRoutine *stronk.StoredRoutine) error
 				weekNumber      int
 				iterationNumber int
 				toFailure       bool
+				createdAt       string
 			)
 
-			if err := rows.Scan(&id, &exercise, &setType, &sqlWeight{&weight}, &setNumber, &reps, &note,
-				&dayNumber, &weekNumber, &iterationNumber, &toFailure); err != nil {
+			if err := rows.Scan(
+				&id, &exercise, &setType, &sqlWeight{&weight},
+				&setNumber, &reps, &note, &dayNumber, &weekNumber,
+				&iterationNumber, &toFailure, &createdAt); err != nil {
 				return fmt.Errorf("failed to scan lift: %w", err)
 			}
 
 			// Find the corresponding routine set
-			routineSetID, err := db.findMatchingRoutineSet(tx, storedRoutine, exercise, setType, 
+			routineSetID, err := db.findMatchingRoutineSet(storedRoutine, exercise, setType,
 				dayNumber, weekNumber, setNumber)
 			if err != nil {
 				// Log and skip this lift if we can't find a match
@@ -892,35 +973,12 @@ func (db *DB) MigrateLiftsToNewFormat(storedRoutine *stronk.StoredRoutine) error
 				continue
 			}
 
-			// Migrate the lift
-			var repsPtr *int
-			if toFailure {
-				// For failure sets, always store the actual reps
-				repsPtr = &reps
-			} else {
-				// For non-failure sets, only store reps if they differ from the routine
-				routineSet, err := db.getRoutineSetFromTx(tx, routineSetID)
-				if err != nil {
-					log.Printf("Warning: Could not get routine set %d: %v", routineSetID, err)
-					repsPtr = &reps // Store anyway
-				} else if routineSet.RepTarget != reps {
-					repsPtr = &reps
-				}
-				// Otherwise, leave repsPtr as nil
-			}
-
-			noteStr := ""
-			if note.Valid {
-				noteStr = note.String
-			}
-
 			// Insert into new lifts table
 			insertQuery := `
-			INSERT INTO lifts_new (routine_set_id, weight, reps, lift_note, day_number, week_number, iteration_number)
-			VALUES (?, ?, ?, ?, ?, ?, ?)`
+			INSERT INTO lifts_new (routine_set_id, weight, reps, lift_note, created_at)
+			VALUES (?, ?, ?, ?, ?)`
 
-			if _, err := tx.Exec(insertQuery, routineSetID, &sqlWeight{&weight}, repsPtr, 
-				nullString(noteStr), dayNumber, weekNumber, iterationNumber); err != nil {
+			if _, err := tx.Exec(insertQuery, routineSetID, &sqlWeight{&weight}, reps, note, createdAt); err != nil {
 				return fmt.Errorf("failed to insert migrated lift: %w", err)
 			}
 
@@ -937,9 +995,8 @@ func (db *DB) MigrateLiftsToNewFormat(storedRoutine *stronk.StoredRoutine) error
 }
 
 // findMatchingRoutineSet finds the routine set ID that matches the given lift parameters
-func (db *DB) findMatchingRoutineSet(tx *sql.Tx, storedRoutine *stronk.StoredRoutine, 
-	exercise stronk.Exercise, setType stronk.SetType, dayNumber, weekNumber, setNumber int) (stronk.RoutineSetID, error) {
-	
+func (db *DB) findMatchingRoutineSet(storedRoutine *stronk.StoredRoutine, exercise stronk.Exercise, setType stronk.SetType, dayNumber, weekNumber, setNumber int) (stronk.RoutineSetID, error) {
+
 	// Navigate through the routine structure to find the matching set
 	if weekNumber >= len(storedRoutine.Weeks) {
 		return 0, fmt.Errorf("week %d not found in routine", weekNumber)
@@ -961,32 +1018,17 @@ func (db *DB) findMatchingRoutineSet(tx *sql.Tx, storedRoutine *stronk.StoredRou
 	}
 
 	if targetMovement == nil {
-		return 0, fmt.Errorf("no movement found for exercise %s, set type %s on day %d, week %d", 
+		return 0, fmt.Errorf("no movement found for exercise %s, set type %s on day %d, week %d",
 			exercise, setType, dayNumber, weekNumber)
 	}
 
 	// Get the set (0-indexed)
 	if setNumber >= len(targetMovement.Sets) {
-		return 0, fmt.Errorf("set %d not found in movement (has %d sets)", 
+		return 0, fmt.Errorf("set %d not found in movement (has %d sets)",
 			setNumber, len(targetMovement.Sets))
 	}
 
 	return targetMovement.Sets[setNumber].ID, nil
-}
-
-// getRoutineSetFromTx gets a routine set within a transaction
-func (db *DB) getRoutineSetFromTx(tx *sql.Tx, id stronk.RoutineSetID) (*stronk.StoredRoutineSet, error) {
-	query := `
-	SELECT id, routine_movement_id, rep_target, to_failure, training_max_percentage, set_order
-	FROM routine_sets
-	WHERE id = ?`
-
-	var set stronk.StoredRoutineSet
-	if err := tx.QueryRow(query, id).Scan(&set.ID, &set.RoutineMovementID, &set.RepTarget, 
-		&set.ToFailure, &set.TrainingMaxPercentage, &set.SetOrder); err != nil {
-		return nil, fmt.Errorf("failed to get routine set: %w", err)
-	}
-	return &set, nil
 }
 
 func repeatedArgs(n int) string {

--- a/db/sqldb/sqldb.go
+++ b/db/sqldb/sqldb.go
@@ -569,6 +569,426 @@ func (db *DB) initMainLifts() error {
 	return nil
 }
 
+// GetCurrentRoutine returns the most recently stored routine
+func (db *DB) GetCurrentRoutine() (*stronk.StoredRoutine, error) {
+	var routine *stronk.StoredRoutine
+	err := db.transact(func(tx *sql.Tx) error {
+		// Get the most recent routine
+		routineQuery := `
+		SELECT id, name, created_at 
+		FROM routines 
+		ORDER BY created_at DESC 
+		LIMIT 1`
+
+		var r stronk.StoredRoutine
+		if err := tx.QueryRow(routineQuery).Scan(&r.ID, &r.Name, &r.CreatedAt); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil // No routine stored yet
+			}
+			return fmt.Errorf("failed to query current routine: %w", err)
+		}
+
+		// Load weeks
+		weeksQuery := `
+		SELECT id, week_name, optional, week_order
+		FROM routine_weeks
+		WHERE routine_id = ?
+		ORDER BY week_order`
+
+		weekRows, err := tx.Query(weeksQuery, r.ID)
+		if err != nil {
+			return fmt.Errorf("failed to query routine weeks: %w", err)
+		}
+		defer weekRows.Close()
+
+		weekMap := make(map[stronk.RoutineWeekID]*stronk.StoredRoutineWeek)
+		for weekRows.Next() {
+			var week stronk.StoredRoutineWeek
+			week.RoutineID = r.ID
+			if err := weekRows.Scan(&week.ID, &week.WeekName, &week.Optional, &week.WeekOrder); err != nil {
+				return fmt.Errorf("failed to scan routine week: %w", err)
+			}
+			weekMap[week.ID] = &week
+			r.Weeks = append(r.Weeks, &week)
+		}
+
+		// Load days
+		if len(r.Weeks) > 0 {
+			var weekIDs []interface{}
+			for _, week := range r.Weeks {
+				weekIDs = append(weekIDs, week.ID)
+			}
+
+			daysQuery := fmt.Sprintf(`
+			SELECT id, routine_week_id, day_name, day_order
+			FROM routine_days
+			WHERE routine_week_id IN %s
+			ORDER BY routine_week_id, day_order`, repeatedArgs(len(weekIDs)))
+
+			dayRows, err := tx.Query(daysQuery, weekIDs...)
+			if err != nil {
+				return fmt.Errorf("failed to query routine days: %w", err)
+			}
+			defer dayRows.Close()
+
+			dayMap := make(map[stronk.RoutineDayID]*stronk.StoredRoutineDay)
+			for dayRows.Next() {
+				var day stronk.StoredRoutineDay
+				if err := dayRows.Scan(&day.ID, &day.RoutineWeekID, &day.DayName, &day.DayOrder); err != nil {
+					return fmt.Errorf("failed to scan routine day: %w", err)
+				}
+				dayMap[day.ID] = &day
+				weekMap[day.RoutineWeekID].Days = append(weekMap[day.RoutineWeekID].Days, &day)
+			}
+
+			// Load movements if we have days
+			if len(dayMap) > 0 {
+				var dayIDs []interface{}
+				for dayID := range dayMap {
+					dayIDs = append(dayIDs, dayID)
+				}
+
+				movementsQuery := fmt.Sprintf(`
+				SELECT rm.id, rm.routine_day_id, e.name, rm.set_type, rm.movement_order
+				FROM routine_movements rm
+				JOIN exercises e ON rm.exercise_id = e.id
+				WHERE rm.routine_day_id IN %s
+				ORDER BY rm.routine_day_id, rm.movement_order`, repeatedArgs(len(dayIDs)))
+
+				movementRows, err := tx.Query(movementsQuery, dayIDs...)
+				if err != nil {
+					return fmt.Errorf("failed to query routine movements: %w", err)
+				}
+				defer movementRows.Close()
+
+				movementMap := make(map[stronk.RoutineMovementID]*stronk.StoredRoutineMovement)
+				for movementRows.Next() {
+					var movement stronk.StoredRoutineMovement
+					if err := movementRows.Scan(&movement.ID, &movement.RoutineDayID, &movement.Exercise, &movement.SetType, &movement.MovementOrder); err != nil {
+						return fmt.Errorf("failed to scan routine movement: %w", err)
+					}
+					movementMap[movement.ID] = &movement
+					dayMap[movement.RoutineDayID].Movements = append(dayMap[movement.RoutineDayID].Movements, &movement)
+				}
+
+				// Load sets if we have movements
+				if len(movementMap) > 0 {
+					var movementIDs []interface{}
+					for movementID := range movementMap {
+						movementIDs = append(movementIDs, movementID)
+					}
+
+					setsQuery := fmt.Sprintf(`
+					SELECT id, routine_movement_id, rep_target, to_failure, training_max_percentage, set_order
+					FROM routine_sets
+					WHERE routine_movement_id IN %s
+					ORDER BY routine_movement_id, set_order`, repeatedArgs(len(movementIDs)))
+
+					setRows, err := tx.Query(setsQuery, movementIDs...)
+					if err != nil {
+						return fmt.Errorf("failed to query routine sets: %w", err)
+					}
+					defer setRows.Close()
+
+					for setRows.Next() {
+						var set stronk.StoredRoutineSet
+						if err := setRows.Scan(&set.ID, &set.RoutineMovementID, &set.RepTarget, &set.ToFailure, &set.TrainingMaxPercentage, &set.SetOrder); err != nil {
+							return fmt.Errorf("failed to scan routine set: %w", err)
+						}
+						movementMap[set.RoutineMovementID].Sets = append(movementMap[set.RoutineMovementID].Sets, &set)
+					}
+				}
+			}
+		}
+
+		routine = &r
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current routine: %w", err)
+	}
+	return routine, nil
+}
+
+// StoreRoutine stores a new routine in the database
+func (db *DB) StoreRoutine(routine *stronk.Routine) (*stronk.StoredRoutine, error) {
+	var stored *stronk.StoredRoutine
+	err := db.transact(func(tx *sql.Tx) error {
+		// Insert routine
+		routineQuery := `
+		INSERT INTO routines (name) 
+		VALUES (?) 
+		RETURNING id`
+
+		var routineID stronk.RoutineID
+		if err := tx.QueryRow(routineQuery, routine.Name).Scan(&routineID); err != nil {
+			return fmt.Errorf("failed to insert routine: %w", err)
+		}
+
+		stored = stronk.ConvertToStoredRoutine(routine, routineID)
+
+		// Insert weeks
+		for _, week := range stored.Weeks {
+			weekQuery := `
+			INSERT INTO routine_weeks (routine_id, week_name, optional, week_order)
+			VALUES (?, ?, ?, ?)
+			RETURNING id`
+
+			if err := tx.QueryRow(weekQuery, routineID, week.WeekName, week.Optional, week.WeekOrder).Scan(&week.ID); err != nil {
+				return fmt.Errorf("failed to insert routine week: %w", err)
+			}
+			week.RoutineID = routineID
+
+			// Insert days
+			for _, day := range week.Days {
+				dayQuery := `
+				INSERT INTO routine_days (routine_week_id, day_name, day_order)
+				VALUES (?, ?, ?)
+				RETURNING id`
+
+				if err := tx.QueryRow(dayQuery, week.ID, day.DayName, day.DayOrder).Scan(&day.ID); err != nil {
+					return fmt.Errorf("failed to insert routine day: %w", err)
+				}
+				day.RoutineWeekID = week.ID
+
+				// Insert movements
+				for _, movement := range day.Movements {
+					movementQuery := `
+					INSERT INTO routine_movements (routine_day_id, exercise_id, set_type, movement_order)
+					VALUES (?, (SELECT id FROM exercises WHERE name = ?), ?, ?)
+					RETURNING id`
+
+					if err := tx.QueryRow(movementQuery, day.ID, movement.Exercise, movement.SetType, movement.MovementOrder).Scan(&movement.ID); err != nil {
+						return fmt.Errorf("failed to insert routine movement: %w", err)
+					}
+					movement.RoutineDayID = day.ID
+
+					// Insert sets
+					for _, set := range movement.Sets {
+						setQuery := `
+						INSERT INTO routine_sets (routine_movement_id, rep_target, to_failure, training_max_percentage, set_order)
+						VALUES (?, ?, ?, ?, ?)
+						RETURNING id`
+
+						if err := tx.QueryRow(setQuery, movement.ID, set.RepTarget, set.ToFailure, set.TrainingMaxPercentage, set.SetOrder).Scan(&set.ID); err != nil {
+							return fmt.Errorf("failed to insert routine set: %w", err)
+						}
+						set.RoutineMovementID = movement.ID
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to store routine: %w", err)
+	}
+	return stored, nil
+}
+
+// GetRoutineSet gets a specific routine set by ID
+func (db *DB) GetRoutineSet(id stronk.RoutineSetID) (*stronk.StoredRoutineSet, error) {
+	var set *stronk.StoredRoutineSet
+	err := db.transact(func(tx *sql.Tx) error {
+		query := `
+		SELECT id, routine_movement_id, rep_target, to_failure, training_max_percentage, set_order
+		FROM routine_sets
+		WHERE id = ?`
+
+		var s stronk.StoredRoutineSet
+		if err := tx.QueryRow(query, id).Scan(&s.ID, &s.RoutineMovementID, &s.RepTarget, &s.ToFailure, &s.TrainingMaxPercentage, &s.SetOrder); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("routine set %d not found", id)
+			}
+			return fmt.Errorf("failed to query routine set: %w", err)
+		}
+		set = &s
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get routine set: %w", err)
+	}
+	return set, nil
+}
+
+// RecordLiftNew records a lift using the new routine system
+func (db *DB) RecordLiftNew(routineSetID stronk.RoutineSetID, weight stronk.Weight, reps *int, note string, day, week, iter int) (stronk.LiftID, error) {
+	var id stronk.LiftID
+	err := db.transact(func(tx *sql.Tx) error {
+		query := `
+		INSERT INTO lifts_new (routine_set_id, weight, reps, lift_note, day_number, week_number, iteration_number)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		RETURNING id`
+
+		if err := tx.QueryRow(query, routineSetID, &sqlWeight{&weight}, reps, nullString(note), day, week, iter).Scan(&id); err != nil {
+			return fmt.Errorf("failed to insert lift: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to record lift: %w", err)
+	}
+	return id, nil
+}
+
+// EditLiftNew edits a lift using the new system
+func (db *DB) EditLiftNew(id stronk.LiftID, note string, reps *int) error {
+	return db.transact(func(tx *sql.Tx) error {
+		query := `
+		UPDATE lifts_new
+		SET reps = ?, lift_note = ?
+		WHERE id = ?`
+		_, err := tx.Exec(query, reps, nullString(note), id)
+		return err
+	})
+}
+
+// MigrateLiftsToNewFormat migrates existing lifts from the old format to the new one
+// This should be called after storing the routine in the database
+func (db *DB) MigrateLiftsToNewFormat(storedRoutine *stronk.StoredRoutine) error {
+	return db.transact(func(tx *sql.Tx) error {
+		// Get all existing lifts
+		liftsQuery := `
+		SELECT l.id, e.name, l.set_type, l.weight, l.set_number, l.reps, l.lift_note,
+		       l.day_number, l.week_number, l.iteration_number, l.to_failure
+		FROM lifts l
+		JOIN exercises e ON l.exercise_id = e.id
+		ORDER BY l.iteration_number, l.week_number, l.day_number, l.created_at`
+
+		rows, err := tx.Query(liftsQuery)
+		if err != nil {
+			return fmt.Errorf("failed to query existing lifts: %w", err)
+		}
+		defer rows.Close()
+
+		var migratedCount int
+		for rows.Next() {
+			var (
+				id              stronk.LiftID
+				exercise        stronk.Exercise
+				setType         stronk.SetType
+				weight          stronk.Weight
+				setNumber       int
+				reps            int
+				note            sql.NullString
+				dayNumber       int
+				weekNumber      int
+				iterationNumber int
+				toFailure       bool
+			)
+
+			if err := rows.Scan(&id, &exercise, &setType, &sqlWeight{&weight}, &setNumber, &reps, &note,
+				&dayNumber, &weekNumber, &iterationNumber, &toFailure); err != nil {
+				return fmt.Errorf("failed to scan lift: %w", err)
+			}
+
+			// Find the corresponding routine set
+			routineSetID, err := db.findMatchingRoutineSet(tx, storedRoutine, exercise, setType, 
+				dayNumber, weekNumber, setNumber)
+			if err != nil {
+				// Log and skip this lift if we can't find a match
+				log.Printf("Warning: Could not find matching routine set for lift %d: %v", id, err)
+				continue
+			}
+
+			// Migrate the lift
+			var repsPtr *int
+			if toFailure {
+				// For failure sets, always store the actual reps
+				repsPtr = &reps
+			} else {
+				// For non-failure sets, only store reps if they differ from the routine
+				routineSet, err := db.getRoutineSetFromTx(tx, routineSetID)
+				if err != nil {
+					log.Printf("Warning: Could not get routine set %d: %v", routineSetID, err)
+					repsPtr = &reps // Store anyway
+				} else if routineSet.RepTarget != reps {
+					repsPtr = &reps
+				}
+				// Otherwise, leave repsPtr as nil
+			}
+
+			noteStr := ""
+			if note.Valid {
+				noteStr = note.String
+			}
+
+			// Insert into new lifts table
+			insertQuery := `
+			INSERT INTO lifts_new (routine_set_id, weight, reps, lift_note, day_number, week_number, iteration_number)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`
+
+			if _, err := tx.Exec(insertQuery, routineSetID, &sqlWeight{&weight}, repsPtr, 
+				nullString(noteStr), dayNumber, weekNumber, iterationNumber); err != nil {
+				return fmt.Errorf("failed to insert migrated lift: %w", err)
+			}
+
+			migratedCount++
+		}
+
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("error iterating through lifts: %w", err)
+		}
+
+		log.Printf("Successfully migrated %d lifts to new format", migratedCount)
+		return nil
+	})
+}
+
+// findMatchingRoutineSet finds the routine set ID that matches the given lift parameters
+func (db *DB) findMatchingRoutineSet(tx *sql.Tx, storedRoutine *stronk.StoredRoutine, 
+	exercise stronk.Exercise, setType stronk.SetType, dayNumber, weekNumber, setNumber int) (stronk.RoutineSetID, error) {
+	
+	// Navigate through the routine structure to find the matching set
+	if weekNumber >= len(storedRoutine.Weeks) {
+		return 0, fmt.Errorf("week %d not found in routine", weekNumber)
+	}
+	week := storedRoutine.Weeks[weekNumber]
+
+	if dayNumber >= len(week.Days) {
+		return 0, fmt.Errorf("day %d not found in week %d", dayNumber, weekNumber)
+	}
+	day := week.Days[dayNumber]
+
+	// Find the movement that matches the exercise and set type
+	var targetMovement *stronk.StoredRoutineMovement
+	for _, movement := range day.Movements {
+		if movement.Exercise == exercise && movement.SetType == setType {
+			targetMovement = movement
+			break
+		}
+	}
+
+	if targetMovement == nil {
+		return 0, fmt.Errorf("no movement found for exercise %s, set type %s on day %d, week %d", 
+			exercise, setType, dayNumber, weekNumber)
+	}
+
+	// Get the set (0-indexed)
+	if setNumber >= len(targetMovement.Sets) {
+		return 0, fmt.Errorf("set %d not found in movement (has %d sets)", 
+			setNumber, len(targetMovement.Sets))
+	}
+
+	return targetMovement.Sets[setNumber].ID, nil
+}
+
+// getRoutineSetFromTx gets a routine set within a transaction
+func (db *DB) getRoutineSetFromTx(tx *sql.Tx, id stronk.RoutineSetID) (*stronk.StoredRoutineSet, error) {
+	query := `
+	SELECT id, routine_movement_id, rep_target, to_failure, training_max_percentage, set_order
+	FROM routine_sets
+	WHERE id = ?`
+
+	var set stronk.StoredRoutineSet
+	if err := tx.QueryRow(query, id).Scan(&set.ID, &set.RoutineMovementID, &set.RepTarget, 
+		&set.ToFailure, &set.TrainingMaxPercentage, &set.SetOrder); err != nil {
+		return nil, fmt.Errorf("failed to get routine set: %w", err)
+	}
+	return &set, nil
+}
+
 func repeatedArgs(n int) string {
 	if n < 1 {
 		// Normally, you wouldn't want to panic in a production application, but

--- a/db/sqldb/util.go
+++ b/db/sqldb/util.go
@@ -19,7 +19,7 @@ func (sw sqlWeight) Value() (driver.Value, error) {
 	return fmt.Sprintf("%d:%s", sw.w.Value, sw.w.Unit), nil
 }
 
-func (sw *sqlWeight) Scan(val interface{}) error {
+func (sw *sqlWeight) Scan(val any) error {
 	if val == nil {
 		return errors.New("weight should always be set")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -31,8 +31,18 @@ type DB interface {
 	SetSmallestDenom(small stronk.Weight) error
 	SmallestDenom() (stronk.Weight, error)
 
-	RecordLift(ex stronk.Exercise, st stronk.SetType, weight stronk.Weight, set int, reps int, note string, day, week, iter int, toFailure bool) (stronk.LiftID, error)
+	// Routine management
+	GetCurrentRoutine() (*stronk.StoredRoutine, error)
+	StoreRoutine(routine *stronk.Routine) (*stronk.StoredRoutine, error)
+	GetRoutineSet(id stronk.RoutineSetID) (*stronk.StoredRoutineSet, error)
+	MigrateLiftsToNewFormat(storedRoutine *stronk.StoredRoutine) error
 
+	// New lift methods
+	RecordLiftNew(routineSetID stronk.RoutineSetID, weight stronk.Weight, reps *int, note string, day, week, iter int) (stronk.LiftID, error)
+	EditLiftNew(id stronk.LiftID, note string, reps *int) error
+
+	// Legacy lift methods (for backward compatibility during migration)
+	RecordLift(ex stronk.Exercise, st stronk.SetType, weight stronk.Weight, set int, reps int, note string, day, week, iter int, toFailure bool) (stronk.LiftID, error)
 	Lift(id stronk.LiftID) (*stronk.Lift, error)
 	EditLift(id stronk.LiftID, note string, reps int) error
 	RecentLifts() ([]*stronk.Lift, error)
@@ -43,9 +53,10 @@ type DB interface {
 type Server struct {
 	mux *http.ServeMux
 
-	routine *stronk.Routine
-	cookies SecureCookie
-	db      DB
+	routine       *stronk.Routine
+	storedRoutine *stronk.StoredRoutine
+	cookies       SecureCookie
+	db            DB
 }
 
 func New(routine *stronk.Routine, db DB) *Server {
@@ -53,12 +64,72 @@ func New(routine *stronk.Routine, db DB) *Server {
 		routine: routine,
 		db:      db,
 	}
+	
+	// Initialize the routine system
+	if err := s.initRoutine(); err != nil {
+		// For now, we'll continue with the old system if initialization fails
+		// In a real deployment, you might want to handle this differently
+		fmt.Printf("Warning: Failed to initialize routine system: %v\n", err)
+	}
+	
 	s.initMux()
 	return s
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mux.ServeHTTP(w, r)
+}
+
+// initRoutine initializes the routine system by checking if the current routine
+// needs to be stored in the database
+func (s *Server) initRoutine() error {
+	// Get the current stored routine
+	storedRoutine, err := s.db.GetCurrentRoutine()
+	if err != nil {
+		return fmt.Errorf("failed to get current routine: %w", err)
+	}
+
+	// If we have no stored routine, store the current one and migrate existing lifts
+	if storedRoutine == nil {
+		stored, err := s.db.StoreRoutine(s.routine)
+		if err != nil {
+			return fmt.Errorf("failed to store initial routine: %w", err)
+		}
+		s.storedRoutine = stored
+		
+		// Migrate existing lifts to the new format
+		if err := s.db.MigrateLiftsToNewFormat(stored); err != nil {
+			return fmt.Errorf("failed to migrate lifts to new format: %w", err)
+		}
+		
+		return nil
+	}
+
+	// Check if the current routine differs from the stored one
+	currentHash, err := s.routine.Hash()
+	if err != nil {
+		return fmt.Errorf("failed to hash current routine: %w", err)
+	}
+
+	// Convert stored routine back to Routine for comparison
+	// For now, we'll just assume they're different if we can't compare easily
+	// A more robust implementation might convert StoredRoutine back to Routine
+	// or store the hash in the database
+	
+	// For simplicity, let's just check if the names match
+	if storedRoutine.Name != s.routine.Name {
+		// Store the new routine
+		stored, err := s.db.StoreRoutine(s.routine)
+		if err != nil {
+			return fmt.Errorf("failed to store updated routine: %w", err)
+		}
+		s.storedRoutine = stored
+		return nil
+	}
+
+	// Use the existing stored routine
+	s.storedRoutine = storedRoutine
+	return nil
 }
 
 func (s *Server) initMux() {
@@ -455,6 +526,22 @@ func (s *Server) nextLiftResponse(w http.ResponseWriter) {
 }
 
 func (s *Server) nextLift() (*nextLiftResp, error) {
+	// Use the stored routine if available, otherwise fall back to the JSON routine
+	if s.storedRoutine != nil {
+		return s.nextLiftWithStoredRoutine()
+	}
+	
+	// Fallback to old logic for backwards compatibility
+	return s.nextLiftLegacy()
+}
+
+func (s *Server) nextLiftWithStoredRoutine() (*nextLiftResp, error) {
+	// TODO: Implement the new logic using stored routines
+	// For now, fall back to legacy method
+	return s.nextLiftLegacy()
+}
+
+func (s *Server) nextLiftLegacy() (*nextLiftResp, error) {
 	// Now the tricky part - we need to figure out the last one that a user
 	// actually completed. Here's our strategy for doing so
 	//  1. Load the users 20 latest lifts, ordered by iteration, then week, then day.
@@ -716,7 +803,14 @@ func (s *Server) serveRecordLift(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id, err := s.db.RecordLift(req.Exercise, req.SetType, weight, req.Set, req.Reps, req.Note, req.Day, req.Week, req.Iteration, req.ToFailure)
+	// Try to use new system if available, otherwise fall back to legacy
+	var id stronk.LiftID
+	if s.storedRoutine != nil {
+		id, err = s.recordLiftWithStoredRoutine(req, weight)
+	} else {
+		id, err = s.db.RecordLift(req.Exercise, req.SetType, weight, req.Set, req.Reps, req.Note, req.Day, req.Week, req.Iteration, req.ToFailure)
+	}
+	
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to record lift: %v", err), http.StatusInternalServerError)
 		return
@@ -729,6 +823,46 @@ func (s *Server) serveRecordLift(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonResp(w, recordLiftResp{id, nextLift})
+}
+
+func (s *Server) recordLiftWithStoredRoutine(req recordReq, weight stronk.Weight) (stronk.LiftID, error) {
+	// Find the routine set that matches this lift
+	routineSet := s.storedRoutine.FindRoutineSet(req.Week, req.Day, 
+		s.findMovementIndex(req.Week, req.Day, req.Exercise, req.SetType), 
+		req.Set)
+	
+	if routineSet == nil {
+		// Fall back to legacy method if we can't find the routine set
+		return s.db.RecordLift(req.Exercise, req.SetType, weight, req.Set, req.Reps, req.Note, req.Day, req.Week, req.Iteration, req.ToFailure)
+	}
+
+	// Determine if we need to store reps
+	var repsPtr *int
+	if req.ToFailure || routineSet.RepTarget != req.Reps {
+		repsPtr = &req.Reps
+	}
+
+	return s.db.RecordLiftNew(routineSet.ID, weight, repsPtr, req.Note, req.Day, req.Week, req.Iteration)
+}
+
+// findMovementIndex finds the index of the movement within a day that matches the given exercise and set type
+func (s *Server) findMovementIndex(weekIdx, dayIdx int, exercise stronk.Exercise, setType stronk.SetType) int {
+	if weekIdx >= len(s.storedRoutine.Weeks) {
+		return -1
+	}
+	week := s.storedRoutine.Weeks[weekIdx]
+
+	if dayIdx >= len(week.Days) {
+		return -1
+	}
+	day := week.Days[dayIdx]
+
+	for i, movement := range day.Movements {
+		if movement.Exercise == exercise && movement.SetType == setType {
+			return i
+		}
+	}
+	return -1
 }
 
 type recordLiftResp struct {

--- a/server/server.go
+++ b/server/server.go
@@ -839,57 +839,6 @@ type lastSet struct {
 	NoneDone      bool
 }
 
-func lastSetDone(day, week, iter int, lifts []*stronk.Lift, dayRoutine *stronk.WorkoutDay) lastSet {
-	// If we have no recorded lifts for the day, it's safe to say the first
-	// movement to do is the first movement we have.
-	if len(lifts) == 0 {
-		return lastSet{NoneDone: true}
-	}
-
-	// We want to match up lifts with our workout to see where we are.
-	idx := len(lifts) - 1
-	for i, mvmt := range dayRoutine.Movements {
-		// Note that we don't actually look at the set info (reps, failure, etc),
-		// moreso just the number of sets because there are lots of practical
-		// reasons that those things might not match up.
-		for j := range mvmt.Sets {
-			lift := lifts[idx]
-
-			// See if the recorded lift matches this.
-			// If it doesn't, we just skip forward to the next exercise of the day.
-			if lift.Exercise != mvmt.Exercise {
-				break
-			}
-			if lift.SetType != mvmt.SetType {
-				break
-			}
-
-			// If the set type and exercise match, there's a good chance that this
-			// lift corresponds to a set of this routine.
-			idx--
-			if idx < 0 {
-				// We've gone through all recorded lifts, meaning that this is the last
-				// set we did.
-				return lastSet{
-					MovementIndex: i,
-					SetIndex:      j,
-					NoneDone:      false,
-				}
-			}
-		}
-	}
-
-	// If we're here, we had lifts that we hadn't looked at, but we went through
-	// all the movements. I don't think this should happen, but I guess it means
-	// we're done with the day?
-	lastMvmt := dayRoutine.Movements[len(dayRoutine.Movements)-1]
-	return lastSet{
-		MovementIndex: len(dayRoutine.Movements) - 1,
-		SetIndex:      len(lastMvmt.Sets) - 1,
-		NoneDone:      false,
-	}
-}
-
 func filterLifts(lifts []*stronk.Lift, day, week, iter int) []*stronk.Lift {
 	var out []*stronk.Lift
 	for _, lift := range lifts {

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -38,14 +39,13 @@ type DB interface {
 	MigrateLiftsToNewFormat(storedRoutine *stronk.StoredRoutine) error
 
 	// New lift methods
-	RecordLiftNew(routineSetID stronk.RoutineSetID, weight stronk.Weight, reps *int, note string, day, week, iter int) (stronk.LiftID, error)
-	EditLiftNew(id stronk.LiftID, note string, reps *int) error
-
-	// Legacy lift methods (for backward compatibility during migration)
-	RecordLift(ex stronk.Exercise, st stronk.SetType, weight stronk.Weight, set int, reps int, note string, day, week, iter int, toFailure bool) (stronk.LiftID, error)
-	Lift(id stronk.LiftID) (*stronk.Lift, error)
+	RecordLift(routineSetID stronk.RoutineSetID, reps int, note string, weight stronk.Weight) (stronk.LiftID, error)
 	EditLift(id stronk.LiftID, note string, reps int) error
+
+	Lift(id stronk.LiftID) (*stronk.Lift, error)
 	RecentLifts() ([]*stronk.Lift, error)
+	LatestLift() (*stronk.Lift, error)
+	LatestLiftPerSetID(setIDs []stronk.RoutineSetID) (map[stronk.RoutineSetID]*stronk.Lift, error)
 	ComparableLifts(ex stronk.Exercise, weight stronk.Weight) (*stronk.ComparableLifts, error)
 	RecentFailureSets() ([]*stronk.Lift, error)
 }
@@ -53,25 +53,25 @@ type DB interface {
 type Server struct {
 	mux *http.ServeMux
 
-	routine       *stronk.Routine
-	storedRoutine *stronk.StoredRoutine
-	cookies       SecureCookie
-	db            DB
+	routine *stronk.StoredRoutine
+	cookies SecureCookie
+	db      DB
 }
 
 func New(routine *stronk.Routine, db DB) *Server {
 	s := &Server{
-		routine: routine,
-		db:      db,
+		db: db,
 	}
-	
+
 	// Initialize the routine system
-	if err := s.initRoutine(); err != nil {
+	storedRoutine, err := s.initRoutine(routine)
+	if err != nil {
 		// For now, we'll continue with the old system if initialization fails
 		// In a real deployment, you might want to handle this differently
-		fmt.Printf("Warning: Failed to initialize routine system: %v\n", err)
+		log.Printf("Warning: Failed to initialize routine system: %v\n", err)
 	}
-	
+	s.routine = storedRoutine
+
 	s.initMux()
 	return s
 }
@@ -82,54 +82,41 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // initRoutine initializes the routine system by checking if the current routine
 // needs to be stored in the database
-func (s *Server) initRoutine() error {
+func (s *Server) initRoutine(routine *stronk.Routine) (*stronk.StoredRoutine, error) {
 	// Get the current stored routine
 	storedRoutine, err := s.db.GetCurrentRoutine()
 	if err != nil {
-		return fmt.Errorf("failed to get current routine: %w", err)
+		return nil, fmt.Errorf("failed to get current routine: %w", err)
 	}
 
-	// If we have no stored routine, store the current one and migrate existing lifts
+	// If we have no stored routine, something went wrong with the DB migration.
 	if storedRoutine == nil {
-		stored, err := s.db.StoreRoutine(s.routine)
-		if err != nil {
-			return fmt.Errorf("failed to store initial routine: %w", err)
-		}
-		s.storedRoutine = stored
-		
-		// Migrate existing lifts to the new format
-		if err := s.db.MigrateLiftsToNewFormat(stored); err != nil {
-			return fmt.Errorf("failed to migrate lifts to new format: %w", err)
-		}
-		
-		return nil
+		return nil, errors.New("no routine stored in database, this shouldn't be possible")
 	}
 
 	// Check if the current routine differs from the stored one
-	currentHash, err := s.routine.Hash()
+	currentHash, err := routine.Hash()
 	if err != nil {
-		return fmt.Errorf("failed to hash current routine: %w", err)
+		return nil, fmt.Errorf("failed to hash current routine: %w", err)
 	}
 
-	// Convert stored routine back to Routine for comparison
-	// For now, we'll just assume they're different if we can't compare easily
-	// A more robust implementation might convert StoredRoutine back to Routine
-	// or store the hash in the database
-	
-	// For simplicity, let's just check if the names match
-	if storedRoutine.Name != s.routine.Name {
-		// Store the new routine
-		stored, err := s.db.StoreRoutine(s.routine)
+	storedHash, err := storedRoutine.ToRoutine().Hash()
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash stored routine: %w", err)
+	}
+
+	// If these don't match, it means the user has uploaded a new routine, and we should store that.
+	if currentHash != storedHash {
+		log.Println("Detected change in routine, storing new one in DB")
+		storedRoutine, err := s.db.StoreRoutine(routine)
 		if err != nil {
-			return fmt.Errorf("failed to store updated routine: %w", err)
+			return nil, fmt.Errorf("failed to store updated routine: %w", err)
 		}
-		s.storedRoutine = stored
-		return nil
+		return storedRoutine, nil
 	}
 
 	// Use the existing stored routine
-	s.storedRoutine = storedRoutine
-	return nil
+	return storedRoutine, nil
 }
 
 func (s *Server) initMux() {
@@ -214,10 +201,6 @@ func (s *Server) serveTrainingMaxes(w http.ResponseWriter, r *http.Request) {
 
 	highestIter := -1
 	for iter := range byIter {
-		if highestIter == -1 {
-			highestIter = iter
-			continue
-		}
 		if iter > highestIter {
 			highestIter = iter
 		}
@@ -291,7 +274,7 @@ func (s *Server) liftOrder() map[stronk.Exercise]int {
 	return m
 }
 
-func exerciseForDay(mvmts []*stronk.Movement) (stronk.Exercise, bool) {
+func exerciseForDay(mvmts []*stronk.StoredRoutineMovement) (stronk.Exercise, bool) {
 	for _, mvmt := range mvmts {
 		if mvmt.SetType != stronk.Main {
 			continue
@@ -526,52 +509,24 @@ func (s *Server) nextLiftResponse(w http.ResponseWriter) {
 }
 
 func (s *Server) nextLift() (*nextLiftResp, error) {
-	// Use the stored routine if available, otherwise fall back to the JSON routine
-	if s.storedRoutine != nil {
-		return s.nextLiftWithStoredRoutine()
-	}
-	
-	// Fallback to old logic for backwards compatibility
-	return s.nextLiftLegacy()
-}
-
-func (s *Server) nextLiftWithStoredRoutine() (*nextLiftResp, error) {
-	// TODO: Implement the new logic using stored routines
-	// For now, fall back to legacy method
-	return s.nextLiftLegacy()
-}
-
-func (s *Server) nextLiftLegacy() (*nextLiftResp, error) {
-	// Now the tricky part - we need to figure out the last one that a user
-	// actually completed. Here's our strategy for doing so
-	//  1. Load the users 20 latest lifts, ordered by iteration, then week, then day.
-	//  2. Correlate that with the routine, using ~~magic~~ (read: bad and hacky heuristics)
-	lifts, err := s.db.RecentLifts()
+	// Just load the latest lift we've done.
+	ll, err := s.db.LatestLift()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load recent lifts: %w", err)
+		return nil, fmt.Errorf("failed to load the latest lift: %w", err)
 	}
 
-	// Map iteration -> week -> day -> set type -> lifts
-	m := make(map[int]map[int]map[int]map[stronk.SetType][]*stronk.Lift)
-	for _, l := range lifts {
-		wm, ok := m[l.IterationNumber]
-		if !ok {
-			wm = make(map[int]map[int]map[stronk.SetType][]*stronk.Lift)
-		}
-		dm, ok := wm[l.WeekNumber]
-		if !ok {
-			dm = make(map[int]map[stronk.SetType][]*stronk.Lift)
-		}
-		stm, ok := dm[l.DayNumber]
-		if !ok {
-			stm = make(map[stronk.SetType][]*stronk.Lift)
-		}
-		lfs := stm[l.SetType]
-		lfs = append(lfs, l)
-		stm[l.SetType] = lfs
-		dm[l.DayNumber] = stm
-		wm[l.WeekNumber] = dm
-		m[l.IterationNumber] = wm
+	var (
+		setIndex, movementIndex, dayIndex, weekIndex, iterIndex int
+		setType                                                 stronk.SetType
+	)
+	if ll != nil {
+		setIndex = ll.SetNumber
+		dayIndex = ll.DayNumber
+		weekIndex = ll.WeekNumber
+		iterIndex = ll.IterationNumber
+		setType = ll.SetType
+	} else {
+		setType = s.routine.Weeks[0].Days[0].Movements[0].SetType
 	}
 
 	skipWeeks, err := s.db.SkippedWeeks()
@@ -584,77 +539,74 @@ func (s *Server) nextLiftLegacy() (*nextLiftResp, error) {
 		swm[weekIter{week: sw.Week, iteration: sw.Iteration}] = true
 	}
 
-	// Load the latest day
-	var day, week, iter int
-	if len(lifts) > 0 {
-		latest := lifts[0]
-		day, week, iter = latest.DayNumber, latest.WeekNumber, latest.IterationNumber
-	}
-
-	routine := s.routine
-
-	// Load the day from the routine.
-	if week >= len(routine.Weeks) {
-		return nil, fmt.Errorf("lift was for week %d that doesn't exist in routine", week)
-	}
-
-	if day >= len(routine.Weeks[week].Days) {
-		return nil, fmt.Errorf("lift was for day %d (week %d) that doesn't exist in routine", day, week)
-	}
-
-	dayRoutine := routine.Weeks[week].Days[day]
-
-	// Now we need to figure out if we finished the day's lifts or not.
-	dayLifts := filterLifts(lifts, day, week, iter)
-	set := lastSetDone(day, week, iter, dayLifts, dayRoutine)
-
-	// Go to the next set in the movement if we have one.
-	// If not, go to the next movement in the routine if we have one.
-	// If not, go to the next day in the week if we have one.
-	// If not, go to the next week in the iteration if we have one.
-	// If not, go to the next iteration, which we can always do.
-	if set.SetIndex < len(dayRoutine.Movements[set.MovementIndex].Sets)-1 {
-		if !set.NoneDone {
-			set.SetIndex++
+	// Now, we calulate the next lift in our routine based on the latest one we've done.
+	week := s.routine.Weeks[weekIndex]
+	day := week.Days[dayIndex]
+	var (
+		smvmt *stronk.StoredRoutineMovement
+	)
+	for idx, mvmt := range day.Movements {
+		if mvmt.SetType == setType {
+			smvmt = mvmt
+			movementIndex = idx
+			break
 		}
-	} else if set.MovementIndex < len(dayRoutine.Movements)-1 {
-		set.SetIndex = 0
-		set.MovementIndex++
-	} else if day < len(routine.Weeks[week].Days)-1 {
-		set.SetIndex = 0
-		set.MovementIndex = 0
-		day++
-	} else if week < len(routine.Weeks)-1 {
-		set.SetIndex = 0
-		set.MovementIndex = 0
-		day = 0
-		week++
-	} else {
-		set.SetIndex = 0
-		set.MovementIndex = 0
-		day = 0
-		week = 0
-		iter++
+	}
+	if smvmt == nil {
+		return nil, fmt.Errorf("no movement found with set type %q on day %d in week %d", setType, dayIndex, weekIndex)
+	}
+
+	// We only increment if we have some previous lift, otherwise we want the actual
+	// zeroth one.
+	if ll != nil {
+		// Go to the next set in the movement if we have one.
+		// If not, go to the next movement in the routine if we have one.
+		// If not, go to the next day in the week if we have one.
+		// If not, go to the next week in the iteration if we have one.
+		// If not, go to the next iteration, which we can always do.
+
+		if setIndex < len(smvmt.Sets)-1 {
+			setIndex++
+		} else if movementIndex < len(day.Movements)-1 {
+			setIndex = 0
+			movementIndex++
+		} else if dayIndex < len(week.Days)-1 {
+			setIndex = 0
+			movementIndex = 0
+			dayIndex++
+		} else if weekIndex < len(s.routine.Weeks)-1 {
+			setIndex = 0
+			movementIndex = 0
+			dayIndex = 0
+			weekIndex++
+		} else {
+			setIndex = 0
+			movementIndex = 0
+			dayIndex = 0
+			weekIndex = 0
+			iterIndex++
+		}
 	}
 
 	// If "the next thing" is a week we skipped, go straight to the next week or iter
-	if swm[weekIter{week: week, iteration: iter}] {
-		if week < len(routine.Weeks)-1 {
-			set.SetIndex = 0
-			set.MovementIndex = 0
-			day = 0
-			week++
+	if swm[weekIter{week: weekIndex, iteration: iterIndex}] {
+		if weekIndex < len(s.routine.Weeks)-1 {
+			setIndex = 0
+			movementIndex = 0
+			dayIndex = 0
+			weekIndex++
 		} else {
-			set.SetIndex = 0
-			set.MovementIndex = 0
-			day = 0
-			week = 0
-			iter++
+			setIndex = 0
+			movementIndex = 0
+			dayIndex = 0
+			weekIndex = 0
+			iterIndex++
 		}
 	}
 
-	// Update our day routine, which may very well have changed.
-	dayRoutine = routine.Weeks[week].Days[day]
+	// Update our day + week bits, which may very well have changed.
+	week = s.routine.Weeks[weekIndex]
+	day = week.Days[dayIndex]
 
 	// Now, load the smallest denom and training maxes, to set the target weights.
 	tms, err := s.db.TrainingMaxes()
@@ -676,75 +628,72 @@ func (s *Server) nextLiftLegacy() (*nextLiftResp, error) {
 		return nil, fmt.Errorf("failed to load smallest denom: %w", err)
 	}
 
-	associatedLift := func(st stronk.SetType, ex stronk.Exercise, setNum int) (stronk.LiftID, bool) {
-		wm, ok := m[iter]
-		if !ok {
-			return 0, false
+	var setIDs []stronk.RoutineSetID
+	for _, mvmt := range day.Movements {
+		for _, set := range mvmt.Sets {
+			setIDs = append(setIDs, set.ID)
 		}
-		dm, ok := wm[week]
-		if !ok {
-			return 0, false
-		}
-		stm, ok := dm[day]
-		if !ok {
-			return 0, false
-		}
-		lfs, ok := stm[st]
-		if !ok {
-			return 0, false
-		}
-		for _, l := range lfs {
-			if l.Exercise != ex {
-				continue
-			}
-			if l.SetNumber != setNum {
-				continue
-			}
-			return l.ID, true
-		}
-		return 0, false
 	}
 
-	mvmts := dayRoutine.Clone().Movements
-	for _, mvmt := range mvmts {
+	liftPerSetID, err := s.db.LatestLiftPerSetID(setIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load latest lift per set ID: %w", err)
+	}
+
+	associatedLiftID := func(id stronk.RoutineSetID) stronk.LiftID {
+		lift, ok := liftPerSetID[id]
+		if !ok {
+			return 0
+		}
+		if lift.IterationNumber != iterIndex {
+			return 0
+		}
+		return lift.ID
+	}
+
+	var workoutMvmts []*stronk.Movement
+	for _, mvmt := range day.Movements {
 		tm, ok := getTM(mvmt.Exercise)
 		if !ok {
 			// Just skip this one if we didn't set it.
 			continue
 		}
-		for i, set := range mvmt.Sets {
-			set.WeightTarget = roundWeight(tm, set.TrainingMaxPercentage, smallest)
-			id, ok := associatedLift(mvmt.SetType, mvmt.Exercise, i)
-			if ok {
-				set.AssociatedLiftID = id
-			}
+		var sets []*stronk.Set
+		for _, set := range mvmt.Sets {
+			weightTarget := roundWeight(tm, set.TrainingMaxPercentage, smallest)
 
-			if !set.ToFailure {
-				continue
+			var comparables *stronk.ComparableLifts
+			if set.ToFailure {
+				if comparables, err = s.db.ComparableLifts(mvmt.Exercise, weightTarget); err != nil {
+					return nil, fmt.Errorf("failed to load comparables: %w", err)
+				}
 			}
-			comparables, err := s.db.ComparableLifts(mvmt.Exercise, set.WeightTarget)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load comparables: %w", err)
-			}
-			set.FailureComparables = comparables
+			sets = append(sets, &stronk.Set{
+				RepTarget:             set.RepTarget,
+				ToFailure:             set.ToFailure,
+				TrainingMaxPercentage: set.TrainingMaxPercentage,
+				WeightTarget:          weightTarget,
+				FailureComparables:    comparables,
+				AssociatedLiftID:      associatedLiftID(set.ID),
+			})
 		}
-	}
-
-	// For JSON serialization
-	if mvmts == nil {
-		mvmts = []*stronk.Movement{}
+		workoutMvmts = append(workoutMvmts, &stronk.Movement{
+			Exercise: mvmt.Exercise,
+			SetType:  mvmt.SetType,
+			Sets:     sets,
+		})
 	}
 
 	return &nextLiftResp{
-		DayNumber:         day,
-		WeekNumber:        week,
-		IterationNumber:   iter,
-		DayName:           dayRoutine.DayName,
-		WeekName:          routine.Weeks[week].WeekName,
-		Workout:           mvmts,
-		NextMovementIndex: set.MovementIndex,
-		NextSetIndex:      set.SetIndex,
-		OptionalWeek:      day == 0 && set.MovementIndex == 0 && set.SetIndex == 0 && routine.Weeks[week].Optional,
+		DayNumber:         dayIndex,
+		WeekNumber:        weekIndex,
+		IterationNumber:   iterIndex,
+		DayName:           day.DayName,
+		WeekName:          week.WeekName,
+		Workout:           workoutMvmts,
+		NextMovementIndex: movementIndex,
+		NextSetIndex:      setIndex,
+		OptionalWeek:      dayIndex == 0 && movementIndex == 0 && setIndex == 0 && week.Optional,
 	}, nil
 }
 
@@ -803,14 +752,17 @@ func (s *Server) serveRecordLift(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try to use new system if available, otherwise fall back to legacy
-	var id stronk.LiftID
-	if s.storedRoutine != nil {
-		id, err = s.recordLiftWithStoredRoutine(req, weight)
-	} else {
-		id, err = s.db.RecordLift(req.Exercise, req.SetType, weight, req.Set, req.Reps, req.Note, req.Day, req.Week, req.Iteration, req.ToFailure)
+	// Find the routine set that matches this lift
+	routineSet := s.routine.FindRoutineSet(req.Week, req.Day,
+		s.findMovementIndex(req.Week, req.Day, req.Exercise, req.SetType),
+		req.Set)
+
+	if routineSet == nil {
+		http.Error(w, "failed to load the relevant routine set", http.StatusInternalServerError)
+		return
 	}
-	
+
+	liftID, err := s.db.RecordLift(routineSet.ID, req.Reps, req.Note, weight)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to record lift: %v", err), http.StatusInternalServerError)
 		return
@@ -822,35 +774,15 @@ func (s *Server) serveRecordLift(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonResp(w, recordLiftResp{id, nextLift})
-}
-
-func (s *Server) recordLiftWithStoredRoutine(req recordReq, weight stronk.Weight) (stronk.LiftID, error) {
-	// Find the routine set that matches this lift
-	routineSet := s.storedRoutine.FindRoutineSet(req.Week, req.Day, 
-		s.findMovementIndex(req.Week, req.Day, req.Exercise, req.SetType), 
-		req.Set)
-	
-	if routineSet == nil {
-		// Fall back to legacy method if we can't find the routine set
-		return s.db.RecordLift(req.Exercise, req.SetType, weight, req.Set, req.Reps, req.Note, req.Day, req.Week, req.Iteration, req.ToFailure)
-	}
-
-	// Determine if we need to store reps
-	var repsPtr *int
-	if req.ToFailure || routineSet.RepTarget != req.Reps {
-		repsPtr = &req.Reps
-	}
-
-	return s.db.RecordLiftNew(routineSet.ID, weight, repsPtr, req.Note, req.Day, req.Week, req.Iteration)
+	jsonResp(w, recordLiftResp{liftID, nextLift})
 }
 
 // findMovementIndex finds the index of the movement within a day that matches the given exercise and set type
 func (s *Server) findMovementIndex(weekIdx, dayIdx int, exercise stronk.Exercise, setType stronk.SetType) int {
-	if weekIdx >= len(s.storedRoutine.Weeks) {
+	if weekIdx >= len(s.routine.Weeks) {
 		return -1
 	}
-	week := s.storedRoutine.Weeks[weekIdx]
+	week := s.routine.Weeks[weekIdx]
 
 	if dayIdx >= len(week.Days) {
 		return -1

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -53,7 +53,7 @@ func TestNextLift(t *testing.T) {
 		}
 
 		var got nextLiftResp
-		dat, err := ioutil.ReadAll(resp.Body)
+		dat, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatalf("failed to read response body: %v", err)
 		}
@@ -71,7 +71,7 @@ func TestNextLift(t *testing.T) {
 
 		resp := w.Result()
 		if status := resp.StatusCode; status != http.StatusOK {
-			t.Fatalf("unexpected response code from server %d, wanted OK", status)
+			t.Fatalf("unexpected response code from server %d, wanted OK: %s", status, w.Body.String())
 		}
 
 		checkAndParseNextLiftResponse(w.Result(), want)
@@ -439,7 +439,7 @@ func TestNextLift(t *testing.T) {
 			}
 
 			var got recordLiftResp
-			dat, err := ioutil.ReadAll(resp.Body)
+			dat, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatalf("failed to read response body: %v", err)
 			}
@@ -766,9 +766,10 @@ func (e *testEnv) smallestDenom(t *testing.T) stronk.Weight {
 }
 
 func setup(t *testing.T) (*Server, *testEnv) {
-	env := &testEnv{db: testdb.New()}
+	routine := loadRoutine(t)
+	env := &testEnv{db: testdb.New(routine)}
 
-	return New(loadRoutine(t), env.db), env
+	return New(routine, env.db), env
 }
 
 func loadRoutine(t *testing.T) *stronk.Routine {

--- a/stronk.go
+++ b/stronk.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 )
 
 var (
@@ -223,8 +224,70 @@ type RoutineSetID int
 type StoredRoutine struct {
 	ID        RoutineID
 	Name      string
-	CreatedAt string
+	CreatedAt time.Time
 	Weeks     []*StoredRoutineWeek
+}
+
+func (s *StoredRoutine) LastSetID() (RoutineSetID, bool) {
+	lastWeekIdx := len(s.Weeks) - 1
+	if lastWeekIdx == -1 {
+		return 0, false
+	}
+	lastWeek := s.Weeks[lastWeekIdx]
+	lastDayIdx := len(lastWeek.Days) - 1
+	if lastDayIdx == -1 {
+		return 0, false
+	}
+	lastDay := lastWeek.Days[lastDayIdx]
+	lastMvmtIdx := len(lastDay.Movements) - 1
+	if lastMvmtIdx == -1 {
+		return 0, false
+	}
+	lastMvmt := lastDay.Movements[lastMvmtIdx]
+	lastSetIdx := len(lastMvmt.Sets) - 1
+	if lastSetIdx == -1 {
+		return 0, false
+	}
+	return lastMvmt.Sets[lastSetIdx].ID, true
+}
+
+func (s *StoredRoutine) ToRoutine() *Routine {
+	var weeks []*WorkoutWeek
+	for _, week := range s.Weeks {
+		var days []*WorkoutDay
+		for _, day := range week.Days {
+			var mvmts []*Movement
+			for _, mvmt := range day.Movements {
+				var sets []*Set
+				for _, set := range mvmt.Sets {
+					sets = append(sets, &Set{
+						RepTarget:             set.RepTarget,
+						ToFailure:             set.ToFailure,
+						TrainingMaxPercentage: set.TrainingMaxPercentage,
+					})
+				}
+				mvmts = append(mvmts, &Movement{
+					Exercise: mvmt.Exercise,
+					SetType:  mvmt.SetType,
+					Sets:     sets,
+				})
+			}
+			days = append(days, &WorkoutDay{
+				DayName:   day.DayName,
+				Movements: mvmts,
+			})
+		}
+		weeks = append(weeks, &WorkoutWeek{
+			WeekName: week.WeekName,
+			Optional: week.Optional,
+			Days:     days,
+		})
+	}
+
+	return &Routine{
+		Name:  s.Name,
+		Weeks: weeks,
+	}
 }
 
 type StoredRoutineWeek struct {
@@ -237,11 +300,11 @@ type StoredRoutineWeek struct {
 }
 
 type StoredRoutineDay struct {
-	ID             RoutineDayID
-	RoutineWeekID  RoutineWeekID
-	DayName        string
-	DayOrder       int
-	Movements      []*StoredRoutineMovement
+	ID            RoutineDayID
+	RoutineWeekID RoutineWeekID
+	DayName       string
+	DayOrder      int
+	Movements     []*StoredRoutineMovement
 }
 
 type StoredRoutineMovement struct {
@@ -266,7 +329,7 @@ type Lift struct {
 	ID           LiftID
 	RoutineSetID RoutineSetID
 	Weight       Weight
-	Reps         *int   // NULL if same as routine or for non-failure sets
+	Reps         int // NULL if same as routine or for non-failure sets
 	Note         string
 
 	// Day - 0, 1, 2, ... in a given week
@@ -280,18 +343,14 @@ type Lift struct {
 	// Derived fields (filled from routine_sets via join)
 	Exercise  Exercise
 	SetType   SetType
-	SetNumber int  // For compatibility with existing code
+	SetNumber int // For compatibility with existing code
 	ToFailure bool
 }
 
 func (l *Lift) AsOneRepMax() Weight {
-	reps := 1 // default to 1 if reps is null
-	if l.Reps != nil {
-		reps = *l.Reps
-	}
 	return Weight{
 		// ORM = Weight + (Weight * Num reps * 0.0333333)
-		Value: int(float64(l.Weight.Value) + 0.033333333*float64(l.Weight.Value)*float64(reps)),
+		Value: int(float64(l.Weight.Value) + 0.033333333*float64(l.Weight.Value)*float64(l.Reps)),
 		Unit:  l.Weight.Unit,
 	}
 }
@@ -392,8 +451,7 @@ func ConvertToStoredRoutine(routine *Routine, routineID RoutineID) *StoredRoutin
 				DayOrder: dayOrder,
 			}
 
-			movementOrder := 0
-			for _, movement := range day.Movements {
+			for movementOrder, movement := range day.Movements {
 				storedMovement := &StoredRoutineMovement{
 					Exercise:      movement.Exercise,
 					SetType:       movement.SetType,
@@ -411,7 +469,6 @@ func ConvertToStoredRoutine(routine *Routine, routineID RoutineID) *StoredRoutin
 				}
 
 				storedDay.Movements = append(storedDay.Movements, storedMovement)
-				movementOrder++
 			}
 
 			storedWeek.Days = append(storedWeek.Days, storedDay)

--- a/stronk.go
+++ b/stronk.go
@@ -2,6 +2,8 @@
 package stronk
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -211,15 +213,61 @@ func (s *Set) Clone() *Set {
 }
 
 type LiftID int
+type RoutineID int
+type RoutineWeekID int
+type RoutineDayID int
+type RoutineMovementID int
+type RoutineSetID int
+
+// Database routine types - these represent the stored routine structure
+type StoredRoutine struct {
+	ID        RoutineID
+	Name      string
+	CreatedAt string
+	Weeks     []*StoredRoutineWeek
+}
+
+type StoredRoutineWeek struct {
+	ID        RoutineWeekID
+	RoutineID RoutineID
+	WeekName  string
+	Optional  bool
+	WeekOrder int
+	Days      []*StoredRoutineDay
+}
+
+type StoredRoutineDay struct {
+	ID             RoutineDayID
+	RoutineWeekID  RoutineWeekID
+	DayName        string
+	DayOrder       int
+	Movements      []*StoredRoutineMovement
+}
+
+type StoredRoutineMovement struct {
+	ID            RoutineMovementID
+	RoutineDayID  RoutineDayID
+	Exercise      Exercise
+	SetType       SetType
+	MovementOrder int
+	Sets          []*StoredRoutineSet
+}
+
+type StoredRoutineSet struct {
+	ID                    RoutineSetID
+	RoutineMovementID     RoutineMovementID
+	RepTarget             int
+	ToFailure             bool
+	TrainingMaxPercentage int
+	SetOrder              int
+}
 
 type Lift struct {
-	ID        LiftID
-	Exercise  Exercise
-	SetType   SetType
-	Weight    Weight
-	SetNumber int
-	Reps      int
-	Note      string
+	ID           LiftID
+	RoutineSetID RoutineSetID
+	Weight       Weight
+	Reps         *int   // NULL if same as routine or for non-failure sets
+	Note         string
 
 	// Day - 0, 1, 2, ... in a given week
 	// Week - 0, 1, 2, ... in a given iteration
@@ -228,13 +276,22 @@ type Lift struct {
 	DayNumber       int
 	WeekNumber      int
 	IterationNumber int
-	ToFailure       bool
+
+	// Derived fields (filled from routine_sets via join)
+	Exercise  Exercise
+	SetType   SetType
+	SetNumber int  // For compatibility with existing code
+	ToFailure bool
 }
 
 func (l *Lift) AsOneRepMax() Weight {
+	reps := 1 // default to 1 if reps is null
+	if l.Reps != nil {
+		reps = *l.Reps
+	}
 	return Weight{
 		// ORM = Weight + (Weight * Num reps * 0.0333333)
-		Value: int(float64(l.Weight.Value) + 0.033333333*float64(l.Weight.Value)*float64(l.Reps)),
+		Value: int(float64(l.Weight.Value) + 0.033333333*float64(l.Weight.Value)*float64(reps)),
 		Unit:  l.Weight.Unit,
 	}
 }
@@ -303,4 +360,88 @@ func abs(x int) int {
 		return -x
 	}
 	return x
+}
+
+// RoutineHash generates a SHA256 hash of the routine structure to detect changes
+func (r *Routine) Hash() (string, error) {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256(b)
+	return fmt.Sprintf("%x", hash), nil
+}
+
+// ConvertToStoredRoutine converts a JSON routine to the stored database format
+func ConvertToStoredRoutine(routine *Routine, routineID RoutineID) *StoredRoutine {
+	stored := &StoredRoutine{
+		ID:   routineID,
+		Name: routine.Name,
+	}
+
+	for weekOrder, week := range routine.Weeks {
+		storedWeek := &StoredRoutineWeek{
+			WeekName:  week.WeekName,
+			Optional:  week.Optional,
+			WeekOrder: weekOrder,
+		}
+
+		for dayOrder, day := range week.Days {
+			storedDay := &StoredRoutineDay{
+				DayName:  day.DayName,
+				DayOrder: dayOrder,
+			}
+
+			movementOrder := 0
+			for _, movement := range day.Movements {
+				storedMovement := &StoredRoutineMovement{
+					Exercise:      movement.Exercise,
+					SetType:       movement.SetType,
+					MovementOrder: movementOrder,
+				}
+
+				for setOrder, set := range movement.Sets {
+					storedSet := &StoredRoutineSet{
+						RepTarget:             set.RepTarget,
+						ToFailure:             set.ToFailure,
+						TrainingMaxPercentage: set.TrainingMaxPercentage,
+						SetOrder:              setOrder,
+					}
+					storedMovement.Sets = append(storedMovement.Sets, storedSet)
+				}
+
+				storedDay.Movements = append(storedDay.Movements, storedMovement)
+				movementOrder++
+			}
+
+			storedWeek.Days = append(storedWeek.Days, storedDay)
+		}
+
+		stored.Weeks = append(stored.Weeks, storedWeek)
+	}
+
+	return stored
+}
+
+// FindRoutineSet locates a specific routine set by coordinates (week, day, movement, set indices)
+func (sr *StoredRoutine) FindRoutineSet(weekIdx, dayIdx, movementIdx, setIdx int) *StoredRoutineSet {
+	if weekIdx >= len(sr.Weeks) {
+		return nil
+	}
+	week := sr.Weeks[weekIdx]
+
+	if dayIdx >= len(week.Days) {
+		return nil
+	}
+	day := week.Days[dayIdx]
+
+	if movementIdx >= len(day.Movements) {
+		return nil
+	}
+	movement := day.Movements[movementIdx]
+
+	if setIdx >= len(movement.Sets) {
+		return nil
+	}
+	return movement.Sets[setIdx]
 }

--- a/testing/testdb/testdb.go
+++ b/testing/testdb/testdb.go
@@ -2,27 +2,169 @@
 package testdb
 
 import (
+	"errors"
 	"fmt"
-	"sort"
 
 	"github.com/bcspragu/stronk"
 )
 
-func New() *DB {
-	return &DB{}
+func New(routine *stronk.Routine) *DB {
+	db := &DB{}
+	if _, err := db.StoreRoutine(routine); err != nil {
+		panic(fmt.Sprintf("failed to store routine: %v", err))
+	}
+	return db
+}
+
+type lift struct {
+	ID           stronk.LiftID
+	RoutineSetID stronk.RoutineSetID
+	Reps         int
+	Note         string
+	Weight       stronk.Weight
 }
 
 type DB struct {
-	lifts          []*stronk.Lift
+	lifts          []*lift
 	trainingMaxes  []*stronk.TrainingMax
 	smallestDenoms []stronk.Weight
 	skippedWeeks   []stronk.SkippedWeek
+	routines       []*stronk.StoredRoutine
+}
+
+func (db *DB) GetCurrentRoutine() (*stronk.StoredRoutine, error) {
+	if len(db.routines) == 0 {
+		return nil, nil
+	}
+	return db.routines[len(db.routines)-1], nil
+}
+func (db *DB) StoreRoutine(routine *stronk.Routine) (*stronk.StoredRoutine, error) {
+	id := stronk.RoutineID(len(db.routines) + 1)
+	storedRoutine := stronk.ConvertToStoredRoutine(routine, id)
+	var (
+		weekID = stronk.RoutineWeekID(1)
+		dayID  = stronk.RoutineDayID(1)
+		mvmtID = stronk.RoutineMovementID(1)
+		setID  = stronk.RoutineSetID(1)
+	)
+	for _, week := range storedRoutine.Weeks {
+		week.ID = weekID
+		weekID++
+		for _, day := range week.Days {
+			day.ID = dayID
+			dayID++
+			for _, mvmt := range day.Movements {
+				mvmt.ID = mvmtID
+				mvmtID++
+				for _, set := range mvmt.Sets {
+					set.ID = setID
+					setID++
+				}
+			}
+		}
+	}
+	db.routines = append(db.routines, storedRoutine)
+	return storedRoutine, nil
+}
+func (db *DB) GetRoutineSet(id stronk.RoutineSetID) (*stronk.StoredRoutineSet, error) {
+	for _, r := range db.routines {
+		for _, w := range r.Weeks {
+			for _, d := range w.Days {
+				for _, m := range d.Movements {
+					for _, s := range m.Sets {
+						if s.ID == id {
+							return s, nil
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("routine set %d not found", id)
+}
+func (db *DB) MigrateLiftsToNewFormat(storedRoutine *stronk.StoredRoutine) error {
+	return errors.New("not relevant to in-memory test DB")
+}
+
+func (db *DB) LatestLift() (*stronk.Lift, error) {
+	if len(db.lifts) == 0 {
+		return nil, nil
+	}
+	return db.toLift(db.lifts[len(db.lifts)-1]), nil
+}
+func (db *DB) LatestLiftPerSetID(setIDs []stronk.RoutineSetID) (map[stronk.RoutineSetID]*stronk.Lift, error) {
+	wantedSetIDs := make(map[stronk.RoutineSetID]bool)
+	for _, id := range setIDs {
+		wantedSetIDs[id] = true
+	}
+
+	out := make(map[stronk.RoutineSetID]*stronk.Lift)
+	for i := len(db.lifts) - 1; i >= 0; i-- {
+		ll := db.lifts[i]
+		if !wantedSetIDs[ll.RoutineSetID] {
+			continue
+		}
+		if _, ok := out[ll.RoutineSetID]; ok {
+			// Already have one for this routine set ID
+			continue
+		}
+		out[ll.RoutineSetID] = db.toLift(ll)
+		if len(out) == len(setIDs) {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (db *DB) toLift(l *lift) *stronk.Lift {
+	var (
+		set  *stronk.StoredRoutineSet
+		mvmt *stronk.StoredRoutineMovement
+		day  *stronk.StoredRoutineDay
+		week *stronk.StoredRoutineWeek
+	)
+outer:
+	for _, r := range db.routines {
+		for _, w := range r.Weeks {
+			for _, d := range w.Days {
+				for _, m := range d.Movements {
+					for _, s := range m.Sets {
+						if s.ID == l.RoutineSetID {
+							set = s
+							mvmt = m
+							day = d
+							week = w
+							break outer
+						}
+					}
+				}
+			}
+		}
+	}
+	if set == nil {
+		panic(fmt.Sprintf("no set found for id %d", l.RoutineSetID))
+	}
+	return &stronk.Lift{
+		ID:           l.ID,
+		RoutineSetID: l.RoutineSetID,
+		Weight:       l.Weight,
+		Reps:         l.Reps,
+		Note:         l.Note,
+
+		DayNumber:       day.DayOrder,
+		WeekNumber:      week.WeekOrder,
+		IterationNumber: 0, // We just make this up for now, I think it's fine?
+		Exercise:        mvmt.Exercise,
+		SetType:         mvmt.SetType,
+		SetNumber:       set.SetOrder,
+		ToFailure:       set.ToFailure,
+	}
 }
 
 func (db *DB) Lift(id stronk.LiftID) (*stronk.Lift, error) {
 	for _, l := range db.lifts {
 		if l.ID == id {
-			return l, nil
+			return db.toLift(l), nil
 		}
 	}
 	return nil, fmt.Errorf("lift %d not found", id)
@@ -41,40 +183,23 @@ func (db *DB) EditLift(id stronk.LiftID, note string, reps int) error {
 
 func (db *DB) RecentLifts() ([]*stronk.Lift, error) {
 	lifts := make([]*stronk.Lift, len(db.lifts))
-	copy(lifts, db.lifts)
 
-	sort.Slice(lifts, func(i, j int) bool {
-		if lifts[i].IterationNumber != lifts[j].IterationNumber {
-			return lifts[i].IterationNumber > lifts[j].IterationNumber
-		}
-
-		if lifts[i].WeekNumber != lifts[j].WeekNumber {
-			return lifts[i].WeekNumber > lifts[j].WeekNumber
-		}
-
-		if lifts[i].DayNumber != lifts[j].DayNumber {
-			return lifts[i].DayNumber > lifts[j].DayNumber
-		}
-		return lifts[i].ID > lifts[j].ID
-	})
+	for i := len(db.lifts) - 1; i >= 0; i-- {
+		ll := db.lifts[i]
+		lifts = append(lifts, db.toLift(ll))
+	}
 
 	return lifts, nil
 }
 
-func (db *DB) RecordLift(ex stronk.Exercise, st stronk.SetType, weight stronk.Weight, set int, reps int, note string, day, week, iter int, toFailure bool) (stronk.LiftID, error) {
+func (db *DB) RecordLift(routineSetID stronk.RoutineSetID, reps int, note string, weight stronk.Weight) (stronk.LiftID, error) {
 	id := stronk.LiftID(len(db.lifts) + 1)
-	db.lifts = append(db.lifts, &stronk.Lift{
-		ID:              id,
-		Exercise:        ex,
-		SetType:         st,
-		Weight:          weight,
-		SetNumber:       set,
-		Reps:            reps,
-		DayNumber:       day,
-		WeekNumber:      week,
-		IterationNumber: iter,
-		Note:            note,
-		ToFailure:       toFailure,
+	db.lifts = append(db.lifts, &lift{
+		ID:           id,
+		RoutineSetID: routineSetID,
+		Weight:       weight,
+		Reps:         reps,
+		Note:         note,
 	})
 	return id, nil
 }


### PR DESCRIPTION
Prior to this PR, you couldn't change your `routine.json` file because it would probably break everything. The reason for this is that lifts were recorded mostly independently of the routine, then correlated back to it heuristically, so changing the routine would break the heuristic.

This PR fixes that by taking the `routine.json` and mapping it into the database, then doing a backfill to migrate all the existing lifts to the new format, where the heuristic correlation happens once and lifts are now mapped to a specific `routine_sets.id` in the database.

When the server starts, we load up the `routine.json` and compare it against the latest one in the database. If they're different (by hash), a new routine is created, and it'll be used once the current lifting cycle finishes.

I let Claude Code do the initial version (see https://github.com/bcspragu/stronk/commit/8e877cd11c06d5f8203d3fc9cf18584094b08e4f for the prompt + code), and then reviewed and tweaked it and updated tests in subsequent commits. It did a pretty good first pass, much of what I tweaked was me changing my mind after the fact.